### PR TITLE
Doc Fix: Slides component demo images' href.

### DIFF
--- a/demos/src/slides/pages/page-one/page-one.html
+++ b/demos/src/slides/pages/page-one/page-one.html
@@ -1,5 +1,5 @@
 <ion-slides loop="true" style="background-color: black">
   <ion-slide *ngFor="let image of [1,2,3,4,5]">
-    <img data-src="../assets/slide{{image}}.jpeg">
+    <img data-src="../../assets/slide{{image}}.jpeg">
   </ion-slide>
 </ion-slides>


### PR DESCRIPTION
#### Short description of what this resolves:
Images for the Slides Component demo were not properly referenced; hence, not showing.

#### Changes proposed in this pull request:

- Image was referenced with . . / instead of . . /. . / 

**Ionic Version**: 2.x, 3.x

**Fixes**: #11652
Change the href attribute for the <image .. /> element in the Slides component view to . . / . . /

I'll create a pull request to resolve this.